### PR TITLE
Add test to check if OpenCV libraries are linked successfully

### DIFF
--- a/test-libraries.sh
+++ b/test-libraries.sh
@@ -1,3 +1,4 @@
+# Tests to check if Python can import these libraries successfully
 python3 -c "\
 try:
     import cv2
@@ -11,3 +12,11 @@ try:
     print('Torch was installed successfully')
 except ImportError:
     print('Error occured, file issue on GitHub repo. PyTorch installed successfully')"
+
+# Test if opencv libs have been linked or not
+if ldconfig -p | grep opencv; then
+    echo "OpenCV libraries are present."
+else
+    echo "No OpenCV libs found, link manually if you believe you've installed successfully"
+    echo "Or try doing sudo ldconfig"
+fi


### PR DESCRIPTION
This PR attempts to solve #7 using:

```bash
 if ldconfig -p | grep opencv; then
     echo "OpenCV libraries are present."
 else
     echo "No OpenCV libs found, link manually if you believe you've installed successfully"
     echo "Or try doing sudo ldconfig"
 fi
```

Tested OK on the local system.

cc: @HimanshuSinghGH 